### PR TITLE
fixing the device flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS 		?= -g -O2 -Wall
+CFLAGS 		?= -g -O2 -Wall -std=c99
 
 PROGRAMS	= jslisten
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ After searching the internet, I found nothing really interesting. Kodi addon wil
 <b>Update 12/22/2018:</b>
 If you have many different /dev/inputs, you can pass it as an arguement at the startup:
 
-```jslisten --device /dev/input/myinput/js0```
+```jslisten --device /dev/input/js0```
+
+** jslisten will also default to listen to the first device found if the defined device is not found.
 
 <b>Update 02/12/2019:</b>
 Changed the default service user to "pi" in jslisten.service
@@ -57,7 +59,7 @@ Also added `--help` for the command line for a brief summary of options.
 ## Installation
 
 Following example for Raspbian. Should work for many other distributions almost the same way.
- * Use the precompiled binary in bin/ or run "# make" to create the binary
+ * run "# make" to create the binary
  * Place the binary to "/opt/bin" (if you change the folder, please update your init script)
  * Copy the configuration script to /etc/jslisten.cfg
  * Modify the configuration script to your needs

--- a/src/jslisten.c
+++ b/src/jslisten.c
@@ -307,7 +307,8 @@ void listenJoy (void) {
   struct udev_enumerate *enumerate;
   struct udev_list_entry *devices, *dev_list_entry;
 
-  joyFD = -1;  // Clear previous joystick
+  // Clear previous joystick
+  joyFD = -1;  
 
   /* Create the udev object */
   udev = udev_new();
@@ -336,8 +337,13 @@ void listenJoy (void) {
 
     if (sysPath != NULL && devPath != NULL && strstr(sysPath, "/js") != 0) {
       syslog (LOG_NOTICE, "Found Device: %s\n", devPath);
-      if ((joyFD = open(devPath, O_RDONLY)) < 0) { // Open the file descriptor
-        syslog (LOG_INFO, "error: failed to open fd\n");
+      if (joyFD < 0 || strcmp(devPath, myDevPath) == 0) {
+        // Open the file descriptor
+        if ((joyFD = open(devPath, O_RDONLY)) < 0) { 
+          syslog (LOG_INFO, "error: failed to open fd\n");
+        } else {
+          syslog (LOG_NOTICE, "Watching: %s\n", devPath);
+        }
       }
     }
 
@@ -346,7 +352,9 @@ void listenJoy (void) {
   /* cleanup */
   udev_enumerate_unref(enumerate);
 
-  if ( joyFD < 0 ) { // Still no joystick found
+  // Still no joystick found
+  if ( joyFD < 0 ) { 
+    syslog (LOG_NOTICE, "No devices found\n");
 
     /* Set up a monitor to monitor input devices */
     mon = udev_monitor_new_from_netlink(udev, "udev");


### PR DESCRIPTION
The last found device was always being the one watched, regardless if a device was specified. This defaults to the first found if the specified device is not found. 